### PR TITLE
Add access to the permission constants

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -297,5 +297,6 @@ class Discordie {
 Discordie.Events = Constants.Events;
 Discordie.StatusTypes = Constants.StatusTypes;
 Discordie.States = Constants.DiscordieState;
+Discordie.Permissions = Constants.Permissions;
 
 module.exports = Discordie;


### PR DESCRIPTION
Really small fix.

Now, it should be possible to check for permissions:
`user.can(Discordie.Permissions.Text.MANAGE_MESSAGES, channel)`
`user.can(Discordie.Permissions.General.KICK_MEMBERS, guild)`

I think this was intended, but never added.