### PR TITLE
Update `ws` to ^1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "requireindex": "^1.1.0",
     "superagent": "^1.4.0",
     "tweetnacl": "^0.14.1",
-    "ws": "^0.8.0"
+    "ws": "^1.1.1"
   },
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
Previously `ws` was quite outdated. The version included had multiple vulernabilities (see [NSP-67](https://nodesecurity.io/advisories/67) and [NSP-120](https://nodesecurity.io/advisories/120)) and also had bugs which caused Discordie to crash the server occasionally. These issues have since been fixed in the version required by this PR.

The upgrade does not include breaking changes applicable to this project.