### PR TITLE
Add option to ignore @everyone and @here

### DIFF
--- a/lib/interfaces/IUser.js
+++ b/lib/interfaces/IUser.js
@@ -103,9 +103,10 @@ class IUser extends IBase {
   /**
    * Checks whether the user is mentioned in a `message`.
    * @param {IMessage} message
+   * @param {boolean} ignoreImplicitMentions
    * @returns {boolean}
    */
-  isMentioned(message) {
+  isMentioned(message, ignoreImplicitMentions) {
     if (!message) return false;
     if (!(message instanceof IMessage)) {
       if (message.id) message = message.id;
@@ -114,7 +115,7 @@ class IUser extends IBase {
     }
 
     return message.mentions.some(mention => mention.id === this.id) ||
-      message.mention_everyone;
+        (ignoreImplicitMentions === true ? false : message.mention_everyone);
   }
 
   /**


### PR DESCRIPTION
While developing my discord bot I needed to filter out `@everyone` and `@here` mentions.
I **did** want to react to `@BotName#xxxx`.

Sadly discordie's `IUser#isMentioned(message)` doesn't offer this functionality.
This PR adds an option to ignore these implicit mentions.