### PR TITLE
Fix getMessages optional parameters

### DIFF
--- a/lib/networking/rest/channels/getMessages.js
+++ b/lib/networking/rest/channels/getMessages.js
@@ -6,8 +6,8 @@ const Endpoints = Constants.Endpoints;
 const apiRequest = require("../../../core/ApiRequest");
 
 module.exports = function(channelId, limit, before, after) {
-  before = before || null;
-  after = after || null;
+  before = before || undefined;
+  after = after || undefined;
 
   return new Promise((rs, rj) => {
     apiRequest


### PR DESCRIPTION
Superagent encodes query({before: null}) as `?before=`

Discord now tries to parse empty strings, resulting in `"Value \"\" is not long."`

I changed the before/after defaults to be undefined instead of null