### PR TITLE
Comply with discords 100 message per fetch limit.

### DIFF
--- a/lib/interfaces/IDirectMessageChannel.js
+++ b/lib/interfaces/IDirectMessageChannel.js
@@ -158,7 +158,7 @@ class IDirectMessageChannel extends IBase {
    *   // message cache is sorted on insertion
    *   // channel.messages[0] will get oldest message
    *   var before = channel.messages[0];
-   *   return channel.fetchMessages(left, before)
+   *   return channel.fetchMessages(Math.min(left, 100), before)
    *          .then(e => onFetch(e, channel, left));
    * }
    * function onFetch(e, channel, left) {


### PR DESCRIPTION
Discord recently changed requesting over 100 messages from a soft fail to a hard fail, and probably for good reason. This change to the example reflects that and only requests 100 messages at a time, causing it to function again. An alternative solution to this would be including Math.min(count, 100) inside the lib as it would simply act as it previously did. I do believe however that discord changed it for a reason, and it may make it clearer to the lib's users when it fails that their is a reason it's only fetching 100 messages.