### PR TITLE
Implements GetChannelMessage Endpoint

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -770,6 +770,8 @@ const Constants = {
     CHANNEL_RECIPIENTS: channelId => `/channels/${channelId}/recipients`,
     CHANNEL_WEBHOOKS: channelId => `/channels/${channelId}/webhooks`,
     MESSAGES: channelId => `/channels/${channelId}/messages`,
+    MESSAGE: (channelId, messageId) => 
+      `/channels/${channelId}/messages/${messageId}`,
     PINS: channelId => `/channels/${channelId}/pins`,
     CHANNELS: "/channels",
     SETTINGS: "/users/@me/settings",

--- a/lib/interfaces/ITextChannel.js
+++ b/lib/interfaces/ITextChannel.js
@@ -139,6 +139,32 @@ class ITextChannel extends IChannel {
   }
 
   /**
+   * Makes a request to fetch a message by its Id.
+   *
+   * This is only available to Bot Accounts and requires 'READ_MESSAGE_HISTORY'
+   * permission on the channel.
+   *
+   * Promise resolves with an Object with following structure:
+   * ```js
+   * {
+   *   message: <IMessage>,
+   * }
+   * ```
+   * @param {String} [message] - Message id
+   * @returns {Promise<Object, Error>}
+   */
+  fetchMessage(messageId) {
+    return new Promise((rs, rj) => {
+      rest(this._discordie).channels.getMessage(this.id, messageId)
+      .then(e => {
+        e.message = this._discordie.Messages.get(e.message.id);
+        return rs(e);
+      })
+      .catch(rj);
+    });
+  }
+
+  /**
    * Creates an array of cached pinned messages in this channel.
    *
    * Pinned message cache is updated only if all pinned messages have been

--- a/lib/networking/rest/channels/getMessage.js
+++ b/lib/networking/rest/channels/getMessage.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const Constants = require("../../../Constants");
+const Events = Constants.Events;
+const Endpoints = Constants.Endpoints;
+const apiRequest = require("../../../core/ApiRequest");
+
+module.exports = function(channelId, messageId) {
+  return new Promise((rs, rj) => {
+    var request = apiRequest
+    .get(this, {
+      url: Endpoints.MESSAGE(channelId, messageId)
+    });
+
+    this._queueManager.put(request, (err, res) => {
+      if (err || !res.ok)
+        return rj(err);
+
+      const event = {
+        message: res.body
+      };
+      this.Dispatcher.emit(Events.LOADED_MORE_MESSAGES, {
+          messages: [res.body]
+      });
+      rs(event);
+    });
+  });
+};


### PR DESCRIPTION
Implementation for [Get Channel Message](https://discordapp.com/developers/docs/resources/channel#get-channel-message) Endpoint.
This allow to fetch message by Id.
Use case: If a Reaction event is received and the message is not cached then it will be received as null, but the data Object contains its Id, after considering if more information on the message is needed, this can be fetched from server.