### PR TITLE
Fix reaction count on new messages

### DIFF
--- a/lib/collections/MessageCollection.js
+++ b/lib/collections/MessageCollection.js
@@ -49,6 +49,7 @@ function updateMessages(channelId, messageId, msg) {
     edited = !!msg.edited_timestamp;
     messages.set(messageId, message = messages.get(messageId).merge(msg));
   } else {
+    if (!msg.reactions) msg.reactions = [];
     messages.set(messageId, message = new Message(msg));
   }
 


### PR DESCRIPTION
The message object returned by the discord api don't always have a `reactions` property. This must be created before to cache the message, or it will use the array object instanced on `lib/models/Message.js`.
In the current behaviour all messages cached while not having a reaction, will have the reference for the same Array Object.