### PR TITLE
Fix `client` not defined

### DIFF
--- a/lib/interfaces/IMessage.js
+++ b/lib/interfaces/IMessage.js
@@ -314,7 +314,7 @@ class IMessage extends IBase {
     return new Promise((rs, rj) => {
       rest(this._discordie)
         .channels.getReactions(this.channel_id, this.id, emoji, limit, after)
-        .then(users => rs(users.map(user => client.Users.get(user.id))))
+        .then(users => rs(users.map(user => this._discordie.Users.get(user.id))))
         .catch(rj);
     });
   }


### PR DESCRIPTION
Not sure how it wasn't noticed before, but eh.