### PR TITLE
Changes to keep up with Discord's API

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -13,6 +13,7 @@ const Permissions = {
     MANAGE_ROLES: 1 << 28,
     MANAGE_WEBHOOKS: 1 << 29,
     MANAGE_EMOJIS: 1 << 30,
+    VIEW_AUDIT_LOGS: 1 << 7
   },
   Text: {
     READ_MESSAGES: 1 << 10,

--- a/lib/core/ApiRequest.js
+++ b/lib/core/ApiRequest.js
@@ -101,6 +101,7 @@ class ApiRequest {
     const token = this._discordie.token;
     const method = this._options.method;
     const query = this._options.query;
+    const reason = this._options.reason;
     const body = this._options.body;
     const attachDelegate = this._options.attachDelegate;
     const rs = this._resolve, rj = this._reject;
@@ -113,6 +114,7 @@ class ApiRequest {
     if (useragent) req.set("User-Agent", useragent);
     if (token) req.set("Authorization", botPrefix + token);
     if (query) req.query(query);
+    if (reason) req.set("X-Audit-Log-Reason", encodeURIComponent(reason))
     if (body) req.send(body);
 
     if (typeof attachDelegate === "function") attachDelegate(req);

--- a/lib/core/ApiRequest.js
+++ b/lib/core/ApiRequest.js
@@ -101,7 +101,6 @@ class ApiRequest {
     const token = this._discordie.token;
     const method = this._options.method;
     const query = this._options.query;
-    const reason = this._options.reason;
     const body = this._options.body;
     const attachDelegate = this._options.attachDelegate;
     const rs = this._resolve, rj = this._reject;
@@ -114,7 +113,6 @@ class ApiRequest {
     if (useragent) req.set("User-Agent", useragent);
     if (token) req.set("Authorization", botPrefix + token);
     if (query) req.query(query);
-    if (reason) req.set("X-Audit-Log-Reason", encodeURIComponent(reason))
     if (body) req.send(body);
 
     if (typeof attachDelegate === "function") attachDelegate(req);

--- a/lib/interfaces/IGuild.js
+++ b/lib/interfaces/IGuild.js
@@ -169,15 +169,6 @@ class IGuild extends IBase {
   }
 
   /**
-   * Returns general channel of this guild.
-   * @returns {ITextChannel}
-   * @readonly
-   */
-  get generalChannel() {
-    return this._discordie.Channels.get(this.id);
-  }
-
-  /**
    * Makes a request to edit this guild,
    * substituting `undefined` or `null` properties with current values.
    *

--- a/lib/interfaces/IGuildMember.js
+++ b/lib/interfaces/IGuildMember.js
@@ -105,9 +105,9 @@ class IGuildMember extends IUser {
    * Makes a request to kick this member (from the guild they belong to).
    * @returns {Promise}
    */
-  kick() {
+  kick(reason) {
     return rest(this._discordie)
-      .guilds.members.kickMember(this._guildId, this.id);
+      .guilds.members.kickMember(this._guildId, this.id, reason);
   }
 
   /**

--- a/lib/interfaces/IGuildMember.js
+++ b/lib/interfaces/IGuildMember.js
@@ -103,6 +103,8 @@ class IGuildMember extends IUser {
 
   /**
    * Makes a request to kick this member (from the guild they belong to).
+   * @param {String} reason
+   *
    * @returns {Promise}
    */
   kick(reason) {

--- a/lib/interfaces/ITextChannel.js
+++ b/lib/interfaces/ITextChannel.js
@@ -51,15 +51,6 @@ class ITextChannel extends IChannel {
   }
 
   /**
-   * Gets a value indicating whether it is a default (general) channel.
-   * @returns {boolean}
-   * @readonly
-   */
-  get isDefaultChannel() {
-    return this.guild_id === this.id;
-  }
-
-  /**
    * Gets a value indicating whether all messages were loaded.
    * @returns {boolean}
    * @readonly

--- a/lib/networking/rest/guilds/members/kickMember.js
+++ b/lib/networking/rest/guilds/members/kickMember.js
@@ -8,7 +8,10 @@ const apiRequest = require("../../../../core/ApiRequest");
 module.exports = function(guildId, userId, reason) {
   return new Promise((rs, rj) => {
     var request = apiRequest
-    .del(this, {url: `${Endpoints.GUILD_MEMBERS(guildId)}/${userId}`, query: reason});
+    .del(this, {
+      url: `${Endpoints.GUILD_MEMBERS(guildId)}/${userId}`,
+      query: {reason}
+    });
 
     this._queueManager.putGuildMemberPatch(request, guildId, (err, res) => {
       return (!err && res.ok) ? rs() : rj(err);

--- a/lib/networking/rest/guilds/members/kickMember.js
+++ b/lib/networking/rest/guilds/members/kickMember.js
@@ -5,10 +5,10 @@ const Events = Constants.Events;
 const Endpoints = Constants.Endpoints;
 const apiRequest = require("../../../../core/ApiRequest");
 
-module.exports = function(guildId, userId) {
+module.exports = function(guildId, userId, reason) {
   return new Promise((rs, rj) => {
     var request = apiRequest
-    .del(this, `${Endpoints.GUILD_MEMBERS(guildId)}/${userId}`);
+    .del(this, {url: `${Endpoints.GUILD_MEMBERS(guildId)}/${userId}`, query: reason});
 
     this._queueManager.putGuildMemberPatch(request, guildId, (err, res) => {
       return (!err && res.ok) ? rs() : rj(err);


### PR DESCRIPTION
This fixes various QOL things related to the evolution of the Discord API.

- [The default general channel is being removed (BREAKING CHANGE)](https://github.com/hammerandchisel/discord-api-docs/pull/329)
- Add reason support to `<IGuildMember>.kick()`
- Add `VIEW_AUDIT_LOGS` permission