### PR TITLE
Automatically set Game.type in setStatus

### DIFF
--- a/lib/interfaces/IAuthenticatedUser.js
+++ b/lib/interfaces/IAuthenticatedUser.js
@@ -172,12 +172,14 @@ class IAuthenticatedUser extends IBase {
    * With multiple sessions status from last connected will override statuses
    * from previous sessions.
    *
+   * Game type can be 0, for playing, or 1 for streaming. Automatically gets set to 0 (playing) if not specified.
+   *
    * > Note: By default Discord client does not display game/status updates for
    * > the user it's logged in into. It will be visible for other users.
    * @param {Object|String} status
    * Object `{status: String, afk: boolean}` or string.
    * Field `afk` changes how Discord handles push notifications.
-   * @param {Object|String|null} [game] - Object `{name: String}` or string
+   * @param {Object|String|null} [game] - Object `{name: String [, type: Integer]}` or string
    * @example
    * var game = {name: "with code"}; // sets status as "Playing with code"
    * var streamingGame = {type: 1, name: "something", url: ""}; // "Streaming"
@@ -205,6 +207,8 @@ class IAuthenticatedUser extends IBase {
 
     if (game === undefined) game = this.game;
     if (typeof game === "string") game = {name: game};
+    if (game && typeof game === 'object' && game.type === undefined) game.type = Constants.ActivityTypes.PLAYING;
+    else if (game === null) game = {name: ""};
 
     status = Object.keys(StatusTypes).map(v => StatusTypes[v])
              .find(v => v === status.toLowerCase());
@@ -230,9 +234,11 @@ class IAuthenticatedUser extends IBase {
    * With multiple sessions status from last connected will override statuses
    * from previous sessions.
    *
+   * Game type can be 0, for playing, or 1 for streaming. Automatically gets set to 0 (playing) if not specified.
+   *
    * > Note: By default Discord client does not display game/status updates for
    * > the user it's logged in into. It will be visible for other users.
-   * @param {Object|String|null} game - Object `{name: String}` or string
+   * @param {Object|String|null} game - Object `{name: String [, type: Integer]}` or string
    * @example
    * var game = {name: "with code"}; // sets game as "Playing with code"
    * var streamingGame = {type: 1, name: "something", url: ""}; // "Streaming"


### PR DESCRIPTION
When setting/updating the authenticated user's status with the current game, the "Playing ...." info was not being updated in the discord client.

After some digging, looks like you have to specify a "type" on the status update in order to get it to show (This must be 0 or 1, Playing or Streaming, respectively).

This PR updates the docs to give some insight as to the requirement of that parameter, and also updates the `updateStatus` method to automatically populate the `type` property with 0 (Playing, from the Constants file) so it works out of the box a little more intutively.